### PR TITLE
fix checkbox issue

### DIFF
--- a/app/src/main/java/orz/ludysu/lrcjaeger/HideFoldersActivity.java
+++ b/app/src/main/java/orz/ludysu/lrcjaeger/HideFoldersActivity.java
@@ -90,6 +90,10 @@ public class HideFoldersActivity extends AppCompatActivity {
                 // this folder was set to be hidden
                 tv.setChecked(false);
                 tv.setTextColor(Color.LTGRAY);
+            } else {
+                // set default status
+                tv.setChecked(true);
+                tv.setTextColor(Color.BLACK);
             }
 
             return convertView;


### PR DESCRIPTION
当文件夹数量超过一个屏幕以后, 勾选/取消第二屏以后的任意项目后,滚动屏幕会导致checkbox的状态显示不正确